### PR TITLE
Fix terrain shader in chrome by explicitly setting precision

### DIFF
--- a/bin/CoreData/Shaders/GLSL/TerrainBlend.glsl
+++ b/bin/CoreData/Shaders/GLSL/TerrainBlend.glsl
@@ -6,7 +6,13 @@
 #include "Fog.glsl"
 
 varying vec2 vTexCoord;
+
+#ifndef GL_ES
 varying vec2 vDetailTexCoord;
+#else
+varying lowp vec2 vDetailTexCoord;
+#endif
+
 varying vec3 vNormal;
 varying vec4 vWorldPos;
 #ifdef PERPIXEL
@@ -35,7 +41,11 @@ uniform sampler2D sDetailMap1;
 uniform sampler2D sDetailMap2;
 uniform sampler2D sDetailMap3;
 
+#ifndef GL_ES
 uniform vec2 cDetailTiling;
+#else
+uniform lowp vec2 cDetailTiling;
+#endif
 
 void VS()
 {


### PR DESCRIPTION
It seems that vec2 in a vertex shader is assumed to be mediump and is lowp in a fragment shader.  Explicitly setting the precision fixes the terrain shader in chrome.